### PR TITLE
Additional translations

### DIFF
--- a/display/source/strings.tr
+++ b/display/source/strings.tr
@@ -1,0 +1,29 @@
+; Miscellaneous DISPLAY loading error messages
+errAlready       DB     "DISPLAY zaten yÅklenmiü", 0dH, 0aH, "$"
+errNoDRDOS       DB     "FD-DISPLAY, DR_KEYB'in bu sÅrÅmÅyle uyumlu deßil", 0dH, 0aH, "$"
+sMemAllocatedBuffers
+                 DB     "Ayrçlan arabellekler: $"
+sInTPA           DB     " (TPA iáinde), $"
+sInXMS           DB     " (XMS$ iáinde)"
+
+; Hardware-driver specific messages
+errAcient        DB     "DISPLAY: Bu tÅr donançm iáin en azçndan EGA adaptîrÅ gerekli", 0dH, 0aH, "$"
+errNoCGA         DB     "DISPLAY: CGA adaptîrÅ bulunamadç", 0dH, 0aH, "$"
+errDrvSpecific   DB     "DISPLAY: SÅrÅcÅ temelli kritik hata", 0dH, 0aH, "$"
+
+; Commandline parsing error messages
+SyntaxErrorStr:         DB      "Sîzdizim hatasç ($"
+SES_ParamRequired       DB      ") Gerekli parametre eksik", 0dH, 0aH, "$"
+SES_UnexpectedEOL       DB      ") Beklenmedik satçr sonu", 0dH, 0aH, "$"
+SES_IllegalChar         DB      ") òzin verilmeyen karakter", 0dH, 0aH, "$"
+SES_NameTooLong         DB      ") Aygçt sÅrÅcÅsÅ adç áok uzun", 0dH, 0aH, "$"
+SES_OpenBrExpected      DB      ") ( bekleniyordu", 0dH, 0aH, "$"
+SES_WrongHwName         DB      ") Bilinmeyen donançm aygçt adç", 0dH, 0aH, "$"
+SES_CommaExpected       DB      ") , bekleniyordu", 0dH, 0aH, "$"
+SES_CloseBrExpected     DB      ") ) bekleniyordu", 0dH, 0aH, "$"
+SES_WrongNumberPars     DB      ") Hatalç parametre sayçsç", 0dH, 0aH, "$"
+SES_TooManyPools        DB      ") Äok fazla yazçlçm kod sayfasç (EN ÄOK=5)", 0dH, 0aH, "$"
+SES_ListTooLong         DB      ") Liste áok uzun", 0dH, 0aH, "$"
+SES_TooManyHWPools      DB      ") Äok fazla donançm kod sayfasç", 0dh, 0ah, "$"
+SES_NoAllocatedBufs     DB      ") Herhangi bir arabellek ayçrmak iáin yetersiz bellek", 0dH, 0aH, "$"
+SES_InvalidParameter    DB      ") Geáersiz parametre", 0dh, 0ah, "$"

--- a/display/source/strings.tr.UTF-8
+++ b/display/source/strings.tr.UTF-8
@@ -1,0 +1,29 @@
+; Miscellaneous DISPLAY loading error messages
+errAlready       DB     "DISPLAY zaten yüklenmiş", 0dH, 0aH, "$"
+errNoDRDOS       DB     "FD-DISPLAY, DR_KEYB'in bu sürümüyle uyumlu değil", 0dH, 0aH, "$"
+sMemAllocatedBuffers
+                 DB     "Ayrılan arabellekler: $"
+sInTPA           DB     " (TPA içinde), $"
+sInXMS           DB     " (XMS$ içinde)"
+
+; Hardware-driver specific messages
+errAcient        DB     "DISPLAY: Bu tür donanım için en azından EGA adaptörü gerekli", 0dH, 0aH, "$"
+errNoCGA         DB     "DISPLAY: CGA adaptörü bulunamadı", 0dH, 0aH, "$"
+errDrvSpecific   DB     "DISPLAY: Sürücü temelli kritik hata", 0dH, 0aH, "$"
+
+; Commandline parsing error messages
+SyntaxErrorStr:         DB      "Sözdizim hatası ($"
+SES_ParamRequired       DB      ") Gerekli parametre eksik", 0dH, 0aH, "$"
+SES_UnexpectedEOL       DB      ") Beklenmedik satır sonu", 0dH, 0aH, "$"
+SES_IllegalChar         DB      ") İzin verilmeyen karakter", 0dH, 0aH, "$"
+SES_NameTooLong         DB      ") Aygıt sürücüsü adı çok uzun", 0dH, 0aH, "$"
+SES_OpenBrExpected      DB      ") ( bekleniyordu", 0dH, 0aH, "$"
+SES_WrongHwName         DB      ") Bilinmeyen donanım aygıt adı", 0dH, 0aH, "$"
+SES_CommaExpected       DB      ") , bekleniyordu", 0dH, 0aH, "$"
+SES_CloseBrExpected     DB      ") ) bekleniyordu", 0dH, 0aH, "$"
+SES_WrongNumberPars     DB      ") Hatalı parametre sayısı", 0dH, 0aH, "$"
+SES_TooManyPools        DB      ") Çok fazla yazılım kod sayfası (EN ÇOK=5)", 0dH, 0aH, "$"
+SES_ListTooLong         DB      ") Liste çok uzun", 0dH, 0aH, "$"
+SES_TooManyHWPools      DB      ") Çok fazla donanım kod sayfası", 0dh, 0ah, "$"
+SES_NoAllocatedBufs     DB      ") Herhangi bir arabellek ayırmak için yetersiz bellek", 0dH, 0aH, "$"
+SES_InvalidParameter    DB      ") Geçersiz parametre", 0dh, 0ah, "$"

--- a/dosutil/help/dosutil.en
+++ b/dosutil/help/dosutil.en
@@ -1,3 +1,3 @@
 DOSUTIL
 
-A selection of usefull BATCH file utilities
+A selection of useful BATCH file utilities

--- a/dosutil/help/dosutil.tr
+++ b/dosutil/help/dosutil.tr
@@ -1,0 +1,3 @@
+DOSUTIL
+
+Yararlç TOPLU òû dosya izlencelerinin bir listesi

--- a/dosutil/help/dosutil.tr.UTF-8
+++ b/dosutil/help/dosutil.tr.UTF-8
@@ -1,0 +1,3 @@
+DOSUTIL
+
+Yararlı TOPLU İŞ dosya izlencelerinin bir listesi

--- a/exe2bin/help/exe2bin.tr
+++ b/exe2bin/help/exe2bin.tr
@@ -1,0 +1,9 @@
+Open Watcom EXE'den ˜kili'ye D”nŸtrc Srm 1.5
+Kaynak kodu  Sybase Open Watcom Kamu Lisans altnda kullanlabilir.
+EXE2BIN [se‡enekler] exe_dosyas[.exe] [bin_dosyas]
+Se‡enekler:
+        /Q        bilgi iletilerini sustur
+        /H        exe stbilgisini g”rntle
+        /R        konum de§iŸtirmeleri g”rntle
+        /L=<seg>  exe_dosyas'n <seg> segmentine taŸ
+        /X        davranŸ geniŸlet, ”rn. dosyalar > 64KB

--- a/exe2bin/help/exe2bin.tr.UTF-8
+++ b/exe2bin/help/exe2bin.tr.UTF-8
@@ -1,0 +1,9 @@
+Open Watcom EXE'den İkili'ye Dönüştürücü Sürüm 1.5
+Kaynak kodu  Sybase Open Watcom Kamu Lisansı altında kullanılabilir.
+EXE2BIN [seçenekler] exe_dosyası[.exe] [bin_dosyası]
+Seçenekler:
+        /Q        bilgi iletilerini sustur
+        /H        exe üstbilgisini görüntüle
+        /R        konum değiştirmeleri görüntüle
+        /L=<seg>  exe_dosyası'nı <seg> segmentine taşı
+        /X        davranışı genişlet, örn. dosyalar > 64KB

--- a/fdisk/help/fdisk.tr
+++ b/fdisk/help/fdisk.tr
@@ -1,0 +1,3 @@
+FDISK
+
+FDISK, sabit disklerde b”lm oluŸturmak ve kaldrmak i‡in kullanlan bir ara‡tr.

--- a/fdisk/help/fdisk.tr.UTF-8
+++ b/fdisk/help/fdisk.tr.UTF-8
@@ -1,0 +1,3 @@
+FDISK
+
+FDISK, sabit disklerde bölüm oluşturmak ve kaldırmak için kullanılan bir araçtır.

--- a/fdshell/help/dosshell.tr
+++ b/fdshell/help/dosshell.tr
@@ -1,0 +1,4 @@
+FDSHELL
+
+FDSHELL, Microsoft DOSSHELL grafik kullanc arabiriminin a‡k kaynakl bir srmdr.
+Gerekirse DOSSHELL.INI dosyasn de§iŸtirin.

--- a/fdshell/help/dosshell.tr.UTF-8
+++ b/fdshell/help/dosshell.tr.UTF-8
@@ -1,0 +1,4 @@
+FDSHELL
+
+FDSHELL, Microsoft DOSSHELL grafik kullanıcı arabiriminin açık kaynaklı bir sürümüdür.
+Gerekirse DOSSHELL.INI dosyasını değiştirin.

--- a/flashrom/help/flashrom.tr
+++ b/flashrom/help/flashrom.tr
@@ -1,0 +1,4 @@
+FLASHROM
+
+FLASHROM sistem BIOS'unuzu yedeklemek ve gÅncellemek iáin bir araátçr.
+Dikkatli kullançlmazsa sisteminizi onarçlamaz duruma getirebilir.

--- a/flashrom/help/flashrom.tr.UTF-8
+++ b/flashrom/help/flashrom.tr.UTF-8
@@ -1,0 +1,4 @@
+FLASHROM
+
+FLASHROM sistem BIOS'unuzu yedeklemek ve güncellemek için bir araçtır.
+Dikkatli kullanılmazsa sisteminizi onarılamaz duruma getirebilir.

--- a/freecom/source/freecom_err.tr
+++ b/freecom/source/freecom_err.tr
@@ -95,7 +95,7 @@ FAIL: (B)aüarçsçz
 ## keys associated with the actions
 S14 (compacted)
 KEYS_IGNORE: yY
-KEYS_RETRY:  tT
+KEYS_RETRY:  dD
 KEYS_ABORT:  iò
 KEYS_FAIL:   bB
 ## embedded strings
@@ -125,6 +125,6 @@ S15
 15: Geáersiz disk deßiüimi
 16: FCB mevcut deßil
 17: Paylaüçm înbelleßi yetersiz
-18: Sayfa kodu uyumsuzlußu
+18: Sayfa kodu uyuümazlçßç
 19: Giriü sonu
 20: Yetersiz disk alanç

--- a/freecom/source/freecom_err.tr.UTF-8
+++ b/freecom/source/freecom_err.tr.UTF-8
@@ -95,7 +95,7 @@ FAIL: (B)aşarısız
 ## keys associated with the actions
 S14 (compacted)
 KEYS_IGNORE: yY
-KEYS_RETRY:  tT
+KEYS_RETRY:  dD
 KEYS_ABORT:  iİ
 KEYS_FAIL:   bB
 ## embedded strings
@@ -125,6 +125,6 @@ S15
 15: Geçersiz disk değişimi
 16: FCB mevcut değil
 17: Paylaşım önbelleği yetersiz
-18: Sayfa kodu uyumsuzluğu
+18: Sayfa kodu uyuşmazlığı
 19: Giriş sonu
 20: Yetersiz disk alanı

--- a/freecom/source/freecom_lng.en
+++ b/freecom/source/freecom_lng.en
@@ -632,7 +632,7 @@ Delete '%s' (Yes/No/All/Quit) ? \
 .
 
 :TEXT_UNKNOWN_FILENAME#1
-<<unkown>>\
+<<unknown>>\
 .
 
 :TEXT_DIRSTACK_EMPTY

--- a/freecom/source/freecom_lng.tr
+++ b/freecom/source/freecom_lng.tr
@@ -650,7 +650,7 @@ Dizin yçßçnç boü.
 etiket iáermiyor
 .
 :TEXT_DIR_HDR_SERIAL_NUMBER#0%
- Birimin Seri Numarasç: %04X-%04X
+ Birim seri numarasç: %04X-%04X
 .
 :TEXT_DIR_FTR_FILES#1%
 %10s dosya\
@@ -1094,7 +1094,7 @@ DIR [sÅrÅcÅ:][yol][dosyaadç] [/P] [/W] [/A[[:]îznitelikler]]
              H  Saklç dosyalar             A  Arüivlenmeye hazçr dosyalar
              S  Sistem dosyalarç           -  hayçr îneki
  /O         Dosyalarç sçralama dÅzenine gîre listeler.
- sortorder   N  Ada gîre (alfabetik)      S  Boyuta gîre (înce kÅáÅßÅ)
+ sortorder   N  Ada gîre (alfabetik)       S  Boyuta gîre (înce kÅáÅßÅ)
              E  Uzantçya gîre (alfabetik)  D  Tarih & zaman (înce eskisi)
              G  înce dizinleri grupla      -  Ters sçralama îneki
              U  Sçralanmamçü		   Varsayçlan /ONG
@@ -1293,8 +1293,7 @@ PROMPT [metin]
 
   metin   Yeni bir komut istemi belirtir.
 
-òstem normal karakterlerden ve Aüaßçdaki îzel kodlardan Oluüturulabilir:
-
+òstem normal karakterlerden ve aüaßçdaki îzel kodlardan oluüturulabilir:
 
   $Q   = (eüit iüareti)
   $$   $ (dollar karakteri)

--- a/freecom/source/freecom_lng.tr.UTF-8
+++ b/freecom/source/freecom_lng.tr.UTF-8
@@ -650,7 +650,7 @@ Dizin yığını boş.
 etiket içermiyor
 .
 :TEXT_DIR_HDR_SERIAL_NUMBER#0%
- Birimin Seri Numarası: %04X-%04X
+ Birim seri numarası: %04X-%04X
 .
 :TEXT_DIR_FTR_FILES#1%
 %10s dosya\
@@ -1094,7 +1094,7 @@ DIR [sürücü:][yol][dosyaadı] [/P] [/W] [/A[[:]öznitelikler]]
              H  Saklı dosyalar             A  Arşivlenmeye hazır dosyalar
              S  Sistem dosyaları           -  hayır öneki
  /O         Dosyaları sıralama düzenine göre listeler.
- sortorder   N  Ada göre (alfabetik)      S  Boyuta göre (önce küçüğü)
+ sortorder   N  Ada göre (alfabetik)       S  Boyuta göre (önce küçüğü)
              E  Uzantıya göre (alfabetik)  D  Tarih & zaman (önce eskisi)
              G  önce dizinleri grupla      -  Ters sıralama öneki
              U  Sıralanmamış		   Varsayılan /ONG
@@ -1293,8 +1293,7 @@ PROMPT [metin]
 
   metin   Yeni bir komut istemi belirtir.
 
-İstem normal karakterlerden ve Aşağıdaki özel kodlardan Oluşturulabilir:
-
+İstem normal karakterlerden ve aşağıdaki özel kodlardan oluşturulabilir:
 
   $Q   = (eşit işareti)
   $$   $ (dollar karakteri)

--- a/md5sum/nls/md5sum.tr.UTF-8
+++ b/md5sum/nls/md5sum.tr.UTF-8
@@ -12,7 +12,7 @@
 0.9:    /B           dosyaları ikili kipte oku (öntanımlı -- /T'yi geçersiz kılar)
 0.10:    /M[:|=]kip  özet kipini seç (SHA veya MD5)
 0.11:/C için girdi, özet oluşturduğunda bu program tarafından stdout üzerinde
- görüntülenen dosya adları ve mesaj özetleri olmalıdır.
+0.12:görüntülenen dosya adları ve mesaj özetleri olmalıdır.
 0.13:/M için bağımsız değişken bir özet kipi olmalıdır ve bu MD5SUM'ın nasıl
 0.14:derlendiğine bağlı olarak SHA, CRC32, SHA256 veya MD5 olabilir.
 

--- a/mirror/help/mirror.tr
+++ b/mirror/help/mirror.tr
@@ -1,0 +1,20 @@
+HELP.TXT
+
+Yardm:
+
+Bu program UNFORMAT yardmyla dosya konum bilgilerini kullanlabilecek her
+kurtarma se‡ene§i i‡in kaydeder.
+
+S”zdizim:
+
+MIRROR [src:]
+MIRROR [/PARTN]
+
+  /PARTN    B”lm tablolarnn bir yede§ini A: srcsndeki diskete
+              PARTNSAV.FIL olarak kaydeder. B”lm tablolar UNFORMAT
+              srm 0.8 ile kurtarlabilir.
+
+
+
+
+

--- a/mirror/help/mirror.tr.UTF-8
+++ b/mirror/help/mirror.tr.UTF-8
@@ -1,0 +1,20 @@
+HELP.TXT
+
+Yardım:
+
+Bu program UNFORMAT yardımıyla dosya konum bilgilerini kullanılabilecek her
+kurtarma seçeneği için kaydeder.
+
+Sözdizim:
+
+MIRROR [sürücü:]
+MIRROR [/PARTN]
+
+  /PARTN    Bölüm tablolarının bir yedeğini A: sürücüsündeki diskete
+              PARTNSAV.FIL olarak kaydeder. Bölüm tabloları UNFORMAT
+              sürüm 0.8 ile kurtarılabilir.
+
+
+
+
+

--- a/nlsfunc/help/nlsfunc.tr
+++ b/nlsfunc/help/nlsfunc.tr
@@ -1,0 +1,24 @@
+FreeDOS NLSFUNC. NLS (Yerel Dil Desteßi) iülevsellißi ekler.
+(C) 2004 Eduardo Casino, GNU GPL, SÅrÅm 2 altçnda yayçmlanmçütçr.
+
+  NLSFUNC [/Y|/?] [[D:][YOL][DOSYA]
+
+  [D:][YOL]DOSYA   NLS iáeren bir dosyaya olan yol
+  /Y               (òsteße baßlç) YES/NO tablosunu yÅkler
+  /?               Kullançm bilgisini yazdçrçr
+
+ôrnek:
+
+  CONFIG.SYS
+     COUNTRY=34,858,C:\COUNTRY.SYS
+
+  AUTOEXEC.BAT
+     LH DISPLAY CON=(EGA,858,2)
+     MODE CON CP PREP=((850) C:\CPI\EGA.CPI)
+     MODE CON CP PREP=((,437) C:\CPI\EGA.CPI)
+     LH NLSFUNC /Y
+
+Sonrasçnda FreeCOM'un CHCP komutunu kullanarak baüka kod sayfasçna geáin.
+
+Kod sayfalarçnç deßiütirmeniz gerekmiyorsa MODE satçrlarçnç yok sayçn.
+

--- a/nlsfunc/help/nlsfunc.tr.UTF-8
+++ b/nlsfunc/help/nlsfunc.tr.UTF-8
@@ -1,0 +1,24 @@
+FreeDOS NLSFUNC. NLS (Yerel Dil Desteği) işlevselliği ekler.
+(C) 2004 Eduardo Casino, GNU GPL, Sürüm 2 altında yayımlanmıştır.
+
+  NLSFUNC [/Y|/?] [[D:][YOL][DOSYA]
+
+  [D:][YOL]DOSYA   NLS içeren bir dosyaya olan yol
+  /Y               (İsteğe bağlı) YES/NO tablosunu yükler
+  /?               Kullanım bilgisini yazdırır
+
+Örnek:
+
+  CONFIG.SYS
+     COUNTRY=34,858,C:\COUNTRY.SYS
+
+  AUTOEXEC.BAT
+     LH DISPLAY CON=(EGA,858,2)
+     MODE CON CP PREP=((850) C:\CPI\EGA.CPI)
+     MODE CON CP PREP=((,437) C:\CPI\EGA.CPI)
+     LH NLSFUNC /Y
+
+Sonrasında FreeCOM'un CHCP komutunu kullanarak başka kod sayfasına geçin.
+
+Kod sayfalarını değiştirmeniz gerekmiyorsa MODE satırlarını yok sayın.
+

--- a/pdtree/source/tree.tr
+++ b/pdtree/source/tree.tr
@@ -1,0 +1,71 @@
+# Messages used by pdTree v1 and FreeDOS tree 3.6
+# Each line is limited to 159 characters unless MAXLINE is changed,
+# but if possible should be limited to 79 per line, with a \n
+# added to indicate go to next line, max 2 lines.
+# The messages are split into sets,
+# where each set corresponds to a given function in pdTree.
+# Set 1, is for main and common strings.
+# Many of the strings are used directly by printf,
+# so when a %? appears, be sure any changes also include the %?
+# where ? is a variable identifier and format.
+# Note: only \\, \n, \r, \t are supported (and a single slash must use \\).
+#
+# common to many functions [Set 1]
+1.1:\n
+# main [Set 1] 
+1.2:Dizin PATH listelemesi\n
+# Must include %s for label 
+1.3:%s disk bîlÅmÅ iáin dizin listesi\n
+# Must include %s for serial #  
+1.4:BîlÅm seri numarasç %s\n
+1.5:Altdizin mevcut deßil\n\n
+1.6: --- SÅrdÅrmek iáin bir dÅßmeye basçn ---\n
+# showUsage [Set 2] 
+2.1:Bir disk bîlÅmÅnÅn veya yolun dizin yapçsçnç grafik biáiminde gîrÅntÅler.\n
+# Each %c below will be replaced with proper switch/option
+2.2:TREE [sÅrÅcÅ:][yol] [%c%c] [%c%c]\n
+2.3:   %c%c   Her bir dizindeki dosya adlarçnç gîrÅntÅler.\n
+2.4:   %c%c   Geniületilmiü karakterler yerine ASCII kullançr.\n
+# showInvalidUsage [Set 3] 
+# Must include the %s for option given.
+3.1:Geáersiz anahtar - %s\n
+# The %c will be replaced with the primary switch (default is /)
+3.2:Kullançm bilgisi iáin TREE %c? yazçn.\n
+#showTooManyOptions
+3.3:Äok fazla parametre - %s\n
+# showVersionInfo [Set 4] 
+# also uses treeDescription, message 2.1
+4.1:FreeDOS ile áalçümak Åzere yazçlmçütçr.\n
+4.2:LFN desteßi ile Win32(c) konsol ve DOS sÅrÅmÅ.\n
+# Must include the %s for version string. 
+4.3:SÅrÅm %s\n
+4.4:Yazan:       Kenneth J. Davis\n
+4.5:Tarih:       2000, 2001, 2004\n
+4.6:òletiüim:    jeremyd@computer.org\n
+4.7:Telif hakkç (c): Kamusal alan [Birleüik Devletler tançmç]\n
+#4.8 is only used when cats support is compiled in.
+4.8:Jim Hall'un <jhall@freedos.org> Cats kitaplçßçnç kullançr\n  sÅrÅm 3.8 Telif hakkç (C) 1999,2000 Jim Hall\n
+#4.20 20-30 reserved for FreeDOS tree derived from Dave Dunfield's tree
+#4.20:Copyright 1995 Dave Dunfield - Freely distributable.\n
+4.20:Telif hakkç 1995, 2000 Dave Dunfield - ôzgÅrce daßçtçlabilir (2000 GPL).\n
+# showInvalidDrive [Set 5] 
+5.1:Geáersiz sÅrÅcÅ belirtimi\n
+# showInvalidPath [Set 6] 
+# Must include %s for the invalid path given. 
+6.1:Geáersiz yol - %s\n
+# misc error conditions [Set 7]
+# showBufferOverrun
+# %u required to show what the buffer's current size is. 
+7.1:Hata: Belirtilen dosya yolu olabilecek en bÅyÅk arabelleßi aüçyor (%u bayt)\n
+# showOutOfMemory
+# %s required to display what directory we were processing when ran out of memory.
+7.2:ûu altdizinde bellek yetersiz: %s\n
+#
+# deprecated [Set 8]
+# 8.1 - 8.10 reserved for option selection characters in earlier releases.
+# parseArguments [Set 8] contains the Character[s] used for
+#   argument processing.  Only the 1st character on a line is used.
+# Primary character used to determine option follows, default is '-'
+8.1:/
+# Secondary character used to determine option follows, default is '/'
+8.2:-

--- a/pdtree/source/tree.tr.UTF-8
+++ b/pdtree/source/tree.tr.UTF-8
@@ -1,0 +1,71 @@
+# Messages used by pdTree v1 and FreeDOS tree 3.6
+# Each line is limited to 159 characters unless MAXLINE is changed,
+# but if possible should be limited to 79 per line, with a \n
+# added to indicate go to next line, max 2 lines.
+# The messages are split into sets,
+# where each set corresponds to a given function in pdTree.
+# Set 1, is for main and common strings.
+# Many of the strings are used directly by printf,
+# so when a %? appears, be sure any changes also include the %?
+# where ? is a variable identifier and format.
+# Note: only \\, \n, \r, \t are supported (and a single slash must use \\).
+#
+# common to many functions [Set 1]
+1.1:\n
+# main [Set 1] 
+1.2:Dizin PATH listelemesi\n
+# Must include %s for label 
+1.3:%s disk bölümü için dizin listesi\n
+# Must include %s for serial #  
+1.4:Bölüm seri numarası %s\n
+1.5:Altdizin mevcut değil\n\n
+1.6: --- Sürdürmek için bir düğmeye basın ---\n
+# showUsage [Set 2] 
+2.1:Bir disk bölümünün veya yolun dizin yapısını grafik biçiminde görüntüler.\n
+# Each %c below will be replaced with proper switch/option
+2.2:TREE [sürücü:][yol] [%c%c] [%c%c]\n
+2.3:   %c%c   Her bir dizindeki dosya adlarını görüntüler.\n
+2.4:   %c%c   Genişletilmiş karakterler yerine ASCII kullanır.\n
+# showInvalidUsage [Set 3] 
+# Must include the %s for option given.
+3.1:Geçersiz anahtar - %s\n
+# The %c will be replaced with the primary switch (default is /)
+3.2:Kullanım bilgisi için TREE %c? yazın.\n
+#showTooManyOptions
+3.3:Çok fazla parametre - %s\n
+# showVersionInfo [Set 4] 
+# also uses treeDescription, message 2.1
+4.1:FreeDOS ile çalışmak üzere yazılmıştır.\n
+4.2:LFN desteği ile Win32(c) konsol ve DOS sürümü.\n
+# Must include the %s for version string. 
+4.3:Sürüm %s\n
+4.4:Yazan:       Kenneth J. Davis\n
+4.5:Tarih:       2000, 2001, 2004\n
+4.6:İletişim:    jeremyd@computer.org\n
+4.7:Telif hakkı (c): Kamusal alan [Birleşik Devletler tanımı]\n
+#4.8 is only used when cats support is compiled in.
+4.8:Jim Hall'un <jhall@freedos.org> Cats kitaplığını kullanır\n  sürüm 3.8 Telif hakkı (C) 1999,2000 Jim Hall\n
+#4.20 20-30 reserved for FreeDOS tree derived from Dave Dunfield's tree
+#4.20:Copyright 1995 Dave Dunfield - Freely distributable.\n
+4.20:Telif hakkı 1995, 2000 Dave Dunfield - Özgürce dağıtılabilir (2000 GPL).\n
+# showInvalidDrive [Set 5] 
+5.1:Geçersiz sürücü belirtimi\n
+# showInvalidPath [Set 6] 
+# Must include %s for the invalid path given. 
+6.1:Geçersiz yol - %s\n
+# misc error conditions [Set 7]
+# showBufferOverrun
+# %u required to show what the buffer's current size is. 
+7.1:Hata: Belirtilen dosya yolu olabilecek en büyük arabelleği aşıyor (%u bayt)\n
+# showOutOfMemory
+# %s required to display what directory we were processing when ran out of memory.
+7.2:Şu altdizinde bellek yetersiz: %s\n
+#
+# deprecated [Set 8]
+# 8.1 - 8.10 reserved for option selection characters in earlier releases.
+# parseArguments [Set 8] contains the Character[s] used for
+#   argument processing.  Only the 1st character on a line is used.
+# Primary character used to determine option follows, default is '-'
+8.1:/
+# Secondary character used to determine option follows, default is '/'
+8.2:-


### PR DESCRIPTION
A couple of notes:

- Turkish tree files seem to be newer than the English ones
- pdtree files seem to be identical with tree ones
- `tr*` for md5sum has been fixed
- Most `tr!`s seem to be okay

BTW, are there string files for `fdisk`? There is only help, and fdisk is an essential utility I think.

PS.
-Fixed two typos in .en string files, please carry them over to the source.

@cardpuncher, any review would be appreciated.