### PR TITLE
Various minor fixes

### DIFF
--- a/fdi-x86/nls/SETUP.FR
+++ b/fdi-x86/nls/SETUP.FR
@@ -19,6 +19,7 @@ AUTO_NO=/s- [O,N]? /fWhite N /fGray
 ABORTED=/fLightRed L'installation de %1 %2 a ‚t‚ annul‚e. /e /fGray /bBlack
 
 PARTITION_AUTO=Partitionner automatiquement le lecteur /fWhite %1 /s- /fGray .
+PARTITION_WARN=/fYellow AVIS : /fGray Une partition FAT16 inf‚rieure … 2 Go est n‚cessaire pour KERNL86.
 PARTITION_MBR=Mettre … jour le Master Boot Record sur le lecteur /fWhite %1 /s- /fGray .
 PARTITION_ACTIVE=D‚finir la partition /fWhite %1 /fGray comme active.
 PARTITION_DONE=/p Vous devez red‚marrer pour que le nouveau partitionnement prenne effet.

--- a/fdi-x86/nls/SETUP.FR.UTF-8
+++ b/fdi-x86/nls/SETUP.FR.UTF-8
@@ -19,6 +19,7 @@ AUTO_NO=/s- [O,N]? /fWhite N /fGray
 ABORTED=/fLightRed L'installation de %1 %2 a été annulée. /e /fGray /bBlack
 
 PARTITION_AUTO=Partitionner automatiquement le lecteur /fWhite %1 /s- /fGray .
+PARTITION_WARN=/fYellow AVIS : /fGray Une partition FAT16 inférieure à 2Go est nécessaire pour KERNL86.
 PARTITION_MBR=Mettre à jour le Master Boot Record sur le lecteur /fWhite %1 /s- /fGray .
 PARTITION_ACTIVE=Définir la partition /fWhite %1 /fGray comme active.
 PARTITION_DONE=/p Vous devez redémarrer pour que le nouveau partitionnement prenne effet.

--- a/fdi-x86/nls/SETUP.TR
+++ b/fdi-x86/nls/SETUP.TR
@@ -19,6 +19,7 @@ AUTO_NO=/s- [E,H]? /fWhite H /fGray
 ABORTED=/fLightRed %1 %2 kurulumu iptal edildi. /e /fGray /bBlack
 
 PARTITION_AUTO=/fWhite %1 /s- /fGray srcsn kendili§inden b”lmlendir.
+PARTITION_WARN=/fYellow ˜KAZ: /fGray KERNL86 i‡in 2 GB de§erinden dŸk bir FAT16 b”lm gereklidir.
 PARTITION_MBR=/fWhite %1 /s- /fGray srcs zerinde Ana ™nykleme Kaydn gncelle.
 PARTITION_ACTIVE=/fWhite %1 /fGray disk b”lmn etkin olarak ayarla.
 PARTITION_DONE=/p Yeni b”lmlendirme Ÿemasnn etkin olabilmesi i‡in bilgisayarnz yeniden baŸlatn.

--- a/fdi-x86/nls/SETUP.TR.UTF-8
+++ b/fdi-x86/nls/SETUP.TR.UTF-8
@@ -19,6 +19,7 @@ AUTO_NO=/s- [E,H]? /fWhite H /fGray
 ABORTED=/fLightRed %1 %2 kurulumu iptal edildi. /e /fGray /bBlack
 
 PARTITION_AUTO=/fWhite %1 /s- /fGray sürücüsünü kendiliğinden bölümlendir.
+PARTITION_WARN=/fYellow İKAZ: /fGray KERNL86 için 2 GB değerinden düşük bir FAT16 bölümü gereklidir.
 PARTITION_MBR=/fWhite %1 /s- /fGray sürücüsü üzerinde Ana Önyükleme Kaydını güncelle.
 PARTITION_ACTIVE=/fWhite %1 /fGray disk bölümünü etkin olarak ayarla.
 PARTITION_DONE=/p Yeni bölümlendirme şemasının etkin olabilmesi için bilgisayarınızı yeniden başlatın.

--- a/fdi/language/fr/FDSETUP.DEF
+++ b/fdi/language/fr/FDSETUP.DEF
@@ -2,7 +2,7 @@
 FreeDOS 1.2 Installer French Translation.
 Provided by: Paul Dufresne
 Contact Email: dufresnep@gmail.com
-Created/Modified: November 10, 2016
+Created/Modified: July 27, 2021
 Released Under GPL v2.0 License.
 *******************************************************************************
 
@@ -231,13 +231,13 @@ PAC_OPTS_D=/w66 /h11 /c
 PAC_FRAME_BD=/w74 /h11 /c
 PAC_OPTS_BD=/w66 /h8 /c
 # vecho "What FreeDOS packages do you want to install?"
-PACS?=Quels paquetages /f %1 %2 /f %3 d‚sirez-vous installer ?
-PACBO="  Uniquement les paquetages essentiels."
-PACBS="  Uniquement les paquetages essentiels avec leur code source."
-PACAO="  Tous les paquetages."
-PACAS="  Tous les paquetages incluant leur code source."
-PACDO_ADV="  Un choix personnel de paquetages binaires."
-PACDS_ADV="  Un choix personnel de paquetages incluant leur code source."
+PACS?=Quels paquets /f %1 %2 /f %3 d‚sirez-vous installer ?
+PACBO="  Uniquement les paquets essentiels."
+PACBS="  Uniquement les paquets essentiels avec leur code source."
+PACAO="  Tous les paquets."
+PACAS="  Tous les paquets incluant leur code source."
+PACDO_ADV="  Un choix personnel de paquets binaires."
+PACDS_ADV="  Un choix personnel de paquets incluant leur code source."
 
 # FDASK700 - Reserved
 
@@ -255,7 +255,7 @@ IBACKUP_DONE=/f %1 Sauvegarde termin‚e.
 
 # Old Package removal
 IRMPACK_FRAME=/w60 /h7 /c
-IRMPACKS=Suppression des anciens paquetages en conflit.
+IRMPACKS=Suppression des anciens paquets en conflit.
 # vecho "Removing old 'base/append' package."
 IRMPACKN=/s- "Suppression du paquet ancien '" /f %1 %2 /f %3 "'."
 
@@ -278,12 +278,12 @@ IXSYS_DONE="Copie des fichiers systŠme termin‚e."
 
 # Package installation.
 IPAC_FRAME=/w60 /h7 /c
-IPACBM="Installation des paquetages."
+IPACBM="Installation des paquets."
 IPACBI=/s- "Installation du paquet '" /f %1 %2 /f %3 "'"
 IPACSM="Installation des codes source."
 IPACSI= /s- "Installation des codes source de '" /f %1 %2 /f %3 "'"
 IPACDONE_FRAME=/w46 /h5 /c
-IPACDONE="Installation des paquetages termin‚e."
+IPACDONE="Installation des paquets termin‚e."
 
 # Config file installation
 ICONFIGS_FRAME=/w64 /h5 /c

--- a/fdi/language/fr/utf-8/FDSETUP.DEF
+++ b/fdi/language/fr/utf-8/FDSETUP.DEF
@@ -2,7 +2,7 @@
 FreeDOS 1.2 Installer French Translation.
 Provided by: Paul Dufresne
 Contact Email: dufresnep@gmail.com
-Created/Modified: November 10, 2016
+Created/Modified: July 27, 2021
 Released Under GPL v2.0 License.
 *******************************************************************************
 
@@ -231,13 +231,13 @@ PAC_OPTS_D=/w66 /h11 /c
 PAC_FRAME_BD=/w74 /h11 /c
 PAC_OPTS_BD=/w66 /h8 /c
 # vecho "What FreeDOS packages do you want to install?"
-PACS?=Quels paquetages /f %1 %2 /f %3 désirez-vous installer ?
-PACBO="  Uniquement les paquetages essentiels."
-PACBS="  Uniquement les paquetages essentiels avec leur code source."
-PACAO="  Tous les paquetages."
-PACAS="  Tous les paquetages incluant leur code source."
-PACDO_ADV="  Un choix personnel de paquetages binaires."
-PACDS_ADV="  Un choix personnel de paquetages incluant leur code source."
+PACS?=Quels paquets /f %1 %2 /f %3 désirez-vous installer ?
+PACBO="  Uniquement les paquets essentiels."
+PACBS="  Uniquement les paquets essentiels avec leur code source."
+PACAO="  Tous les paquets."
+PACAS="  Tous les paquets incluant leur code source."
+PACDO_ADV="  Un choix personnel de paquets binaires."
+PACDS_ADV="  Un choix personnel de paquets incluant leur code source."
 
 # FDASK700 - Reserved
 
@@ -255,7 +255,7 @@ IBACKUP_DONE=/f %1 Sauvegarde terminée.
 
 # Old Package removal
 IRMPACK_FRAME=/w60 /h7 /c
-IRMPACKS=Suppression des anciens paquetages en conflit.
+IRMPACKS=Suppression des anciens paquets en conflit.
 # vecho "Removing old 'base/append' package."
 IRMPACKN=/s- "Suppression du paquet ancien '" /f %1 %2 /f %3 "'."
 
@@ -278,12 +278,12 @@ IXSYS_DONE="Copie des fichiers système terminée."
 
 # Package installation.
 IPAC_FRAME=/w60 /h7 /c
-IPACBM="Installation des paquetages."
+IPACBM="Installation des paquets."
 IPACBI=/s- "Installation du paquet '" /f %1 %2 /f %3 "'"
 IPACSM="Installation des codes source."
 IPACSI= /s- "Installation des codes source de '" /f %1 %2 /f %3 "'"
 IPACDONE_FRAME=/w46 /h5 /c
-IPACDONE="Installation des paquetages terminée."
+IPACDONE="Installation des paquets terminée."
 
 # Config file installation
 ICONFIGS_FRAME=/w64 /h5 /c

--- a/pkgtools/nls/PKGINFO.TR
+++ b/pkgtools/nls/PKGINFO.TR
@@ -97,5 +97,6 @@ HELP.26=
 HELP.27=Äeüitli seáenekler:
 HELP.28=
 HELP.29=     $VER        SÅrÅm verilerini gîrÅntÅle
-HELP.30=     $NLS lang   lang lisançnda tercÅmeleri sistem ayarlarç yerine kullan
+HELP.30=     $NLS lang   lang lisançnda tercÅmeleri sistem ayarlarç yerine
+HELP.31=                 kullan
 HELP.32=     //          Seáenek karakteri iáin / kullançmçnç zorla


### PR DESCRIPTION
Fix a line numbering issue in PKGINFO.TR spotted thanks to the report.txt file, and use only "paquet" in the French translation of FDSETUP.DEF for consistency purposes. Also, add the French & Turkish translations of the 'PARTITION_WARN' line for fdi-x86, again spotted thanks to the report.txt file.