### PR TITLE
sort: Fix encoding for Spanish and provide UTF-8

### DIFF
--- a/sort/nls/sort.es.UTF-8
+++ b/sort/nls/sort.es.UTF-8
@@ -1,16 +1,16 @@
-# Archivo de idioma Espa¤ol CP850
+# Archivo de idioma EspaÃ±ol CP850
 # Basado en el archivo sort.en
 # Traducido por Lorenzo del Toro Saravia
 #
-2.0:Par metro no v lido\r\n
+2.0:ParÃ¡metro no vÃ¡lido\r\n
 0.0:    SORT [/R] [/+num] [/A] [/?] [archivo]\r\n
 0.1:    /R    Invertir el orden\r\n
-0.2:    /A    Ordenaci¢n ASCII (sin COUNTRY / NLS)\r\n
+0.2:    /A    OrdenaciÃ³n ASCII (sin COUNTRY / NLS)\r\n
 0.3:    /+num comienza a ordenar desde la columna num, basado en 1\r\n
 0.4:    /?    ayuda\r\n
 2.1:Error leyendo la tabla de ordenar COUNTRY / NLS\r\n
-2.2:NLS / COUNTRY s¢lo soportado por DOS 3.3 o superior\r\n
+2.2:NLS / COUNTRY sÃ³lo soportado por DOS 3.3 o superior\r\n
 2.3:SORT: No se puede abrir el archivo
 2.4: para lectura\r\n
 2.5:SORT: No hay memoria suficiente\r\n
-2.6:SORT: el n£mero de registros excede el m ximo\r\n
+2.6:SORT: el nÃºmero de registros excede el mÃ¡ximo\r\n


### PR DESCRIPTION
Not quite sure what had happened to the encoding of this file, but it's now in CP850. I've also supplied the UTF-8.