### PR TITLE
Fix EDICT hanging when LANG is set to FR

### DIFF
--- a/edict/nls/edict.fr
+++ b/edict/nls/edict.fr
@@ -8,7 +8,7 @@ HELP_03="  /f <nomfich>   sp‚cifier le nom de fichier"
 HELP_04="  /p <limite>    limiter le nombre maximal des passes suppl‚mentaires"
 HELP_05=
 HELP_06="  /t <type>      outrepasser bios et choisir r‚glages pour le disque"
-HELP_07="                 (0=360Kib, 1=1.2 Mib, 2=720Kib, 3=1.44Mib, a=auto)"
+HELP_07="                 (0=360Kib, 1=1.2Mib, 2=720Kib, 3=1.44Mib, a=auto)"
 HELP_08=
 HELP_09="  /c <nombre>    outrepasser le nombre de cylindre/pistes (0-1023)"
 HELP_0a="  /r <nombre>    outrepasser le nombre de faces/tˆtes par piste (0-255)"

--- a/edict/nls/edict.fr
+++ b/edict/nls/edict.fr
@@ -1,4 +1,4 @@
-TITLE=Outil am‚lior‚ de cr‚ation d'image disque, version %_ %s
+TITLE="Outil am‚lior‚ de cr‚ation d'image disque", version %_ %s
 COPYRIGHT=Copyright (c) 2018, Jerome Shidel
 
 HELP_00="Informations sur les options d'EDICT : "
@@ -8,7 +8,7 @@ HELP_03="  /f <nomfich>   sp‚cifier le nom de fichier"
 HELP_04="  /p <limite>    limiter le nombre maximal des passes suppl‚mentaires"
 HELP_05=
 HELP_06="  /t <type>      outrepasser bios et choisir r‚glages pour le disque"
-HELP_07="                 (0=360Kib, 1=1.2Mib, 2=720Kib, 3=1.44Mib, a=auto)"
+HELP_07="                 (0=360Kib, 1=1.2 Mib, 2=720Kib, 3=1.44Mib, a=auto)"
 HELP_08=
 HELP_09="  /c <nombre>    outrepasser le nombre de cylindre/pistes (0-1023)"
 HELP_0a="  /r <nombre>    outrepasser le nombre de faces/tˆtes par piste (0-255)"
@@ -45,17 +45,17 @@ DRIVE_TYPE_05=autre type de lecteur
 
 DRIVE_SPEC=%i %_ octets, %_ %I %_ secteurs, %_ %I %_ pistes, %_ %I %_ face(s)
 
-PASS_LIMIT=Jusqu'… %_ %i %_ passes suppl‚mentaire autoris‚es pour lire la d7
+PASS_LIMIT="Jusqu'… %_ %i %_ passes suppl‚mentaire autoris‚es pour lire la d7"
 BUFFERS=%i %_ octet de tampon disquette, %_ %i %_ octet de tampon de piste
 
-PASS=Passe le lecture de diquette # %i. %_ %i %_ secteurs restants.
+PASS=Passe le lecture de disquette # %i. %_ %i %_ secteurs restants.
 
 READ_FAST=LECTURE DE LA PISTE : %_ %i, TÒTE : %_ %i
 READ_SLOW=LECTURE DE LA PISTE : %_ %i, TÒTE : %_ %i, SECTEUR : %_ %i
 
-FAILED=chec du processus de cr‚ation d'image.
-ABORTED=Annulation du processus de cr‚ation d'image.
-COMPLETED=Processus de cr‚ation d'image termin‚.
+FAILED="chec du processus de cr‚ation d'image."
+ABORTED="Annulation du processus de cr‚ation d'image."
+COMPLETED="Processus de cr‚ation d'image termin‚."
 
 ; With a little modification, these BIOS and DOS error message texts are a
 ; slimmed down version of those available online from a great DOS and ASM
@@ -63,8 +63,8 @@ COMPLETED=Processus de cr‚ation d'image termin‚.
 
 BErr=%r "Code d'erreur du BIOS : 0x" %b %_ --> %_
 BErr_01=mauvaise commande transmise au lecteur
-BErr_02=marque d'adresse introuvable ou secteur d‚fectueux
-BErr_03=erreur de protection d'‚criture sur la disquette
+BErr_02="marque d'adresse introuvable ou secteur d‚fectueux"
+BErr_03="erreur de protection d'‚criture sur la disquette"
 BErr_04=secteur introuvable
 BErr_05=‚chec de la r‚initialisation du disque fixe
 BErr_06=disquette chang‚e ou enlev‚e
@@ -75,18 +75,18 @@ BErr_0a=indicateur de secteur de disque fixe incorrect
 BErr_0b=mauvais cylindre de disque fixe
 BErr_0c=piste non prise en charge
 BErr_0d=nombre de secteurs invalide sur le format de disque fixe
-BErr_0e=marque d'adresse de donn‚es contr“l‚e par disque fixe d‚tect‚e
-BErr_0f=niveau d'arbitrage DMA de disque fixe hors plage
+BErr_0e="marque d'adresse de donn‚es contr“l‚e par disque fixe d‚tect‚e"
+BErr_0f="niveau d'arbitrage DMA de disque fixe hors plage"
 BErr_10=erreur ECC/CRC pendant la lecture du disque
 BErr_11=erreur de donn‚es de disque fixe r‚cup‚rable, donn‚es corrig‚es par ECC
 BErr_20=erreur de contr“leur
 BErr_40=‚chec de recherche
-BErr_80=le lecteur n'est pas prˆt
-BErr_aa=le lecteur de disque fixe n'est pas prˆt
+BErr_80="le lecteur n'est pas prˆt"
+BErr_aa="le lecteur de disque fixe n'est pas prˆt"
 BErr_bb=erreur non d‚finie du disque fixe
-BErr_cc=erreur d'‚criture de disque fixe sur le lecteur choisi
-BErr_e0=erreur d'‚tat du disque fixe
-BErr_ff=‚chec de l'op‚ration de d‚tection
+BErr_cc="erreur d'‚criture de disque fixe sur le lecteur choisi"
+BErr_e0="erreur d'‚tat du disque fixe"
+BErr_ff="‚chec de l'op‚ration de d‚tection"
 
 DErr=%r "Code d'erreur DOS : 0x" %b %_ --> %_
 DErr_01=Num‚ro de fonction invalide
@@ -97,4 +97,4 @@ DErr_05=AccŠs refus‚
 DErr_06=Handle invalide
 DErr_08=M‚moire insuffisante
 DErr_0f=Lecteur invalide sp‚cifi‚
-DErr_15=Le lecteur n'est pas prˆt
+DErr_15="Le lecteur n'est pas prˆt"

--- a/edict/nls/edict.fr.UTF-8
+++ b/edict/nls/edict.fr.UTF-8
@@ -1,4 +1,4 @@
-TITLE=Outil amélioré de création d'image disque, version %_ %s
+TITLE="Outil amélioré de création d'image disque", version %_ %s
 COPYRIGHT=Copyright (c) 2018, Jerome Shidel
 
 HELP_00="Informations sur les options d'EDICT : "
@@ -45,17 +45,17 @@ DRIVE_TYPE_05=autre type de lecteur
 
 DRIVE_SPEC=%i %_ octets, %_ %I %_ secteurs, %_ %I %_ pistes, %_ %I %_ face(s)
 
-PASS_LIMIT=Jusqu'à %_ %i %_ passes supplémentaire autorisées pour lire la d7
+PASS_LIMIT="Jusqu'à %_ %i %_ passes supplémentaire autorisées pour lire la d7"
 BUFFERS=%i %_ octet de tampon disquette, %_ %i %_ octet de tampon de piste
 
-PASS=Passe le lecture de diquette # %i. %_ %i %_ secteurs restants.
+PASS=Passe le lecture de disquette # %i. %_ %i %_ secteurs restants.
 
 READ_FAST=LECTURE DE LA PISTE : %_ %i, TÊTE : %_ %i
 READ_SLOW=LECTURE DE LA PISTE : %_ %i, TÊTE : %_ %i, SECTEUR : %_ %i
 
-FAILED=Échec du processus de création d'image.
-ABORTED=Annulation du processus de création d'image.
-COMPLETED=Processus de création d'image terminé.
+FAILED="Échec du processus de création d'image."
+ABORTED="Annulation du processus de création d'image."
+COMPLETED="Processus de création d'image terminé."
 
 ; With a little modification, these BIOS and DOS error message texts are a
 ; slimmed down version of those available online from a great DOS and ASM
@@ -63,8 +63,8 @@ COMPLETED=Processus de création d'image terminé.
 
 BErr=%r "Code d'erreur du BIOS : 0x" %b %_ --> %_
 BErr_01=mauvaise commande transmise au lecteur
-BErr_02=marque d'adresse introuvable ou secteur défectueux
-BErr_03=erreur de protection d'écriture sur la disquette
+BErr_02="marque d'adresse introuvable ou secteur défectueux"
+BErr_03="erreur de protection d'écriture sur la disquette"
 BErr_04=secteur introuvable
 BErr_05=échec de la réinitialisation du disque fixe
 BErr_06=disquette changée ou enlevée
@@ -75,18 +75,18 @@ BErr_0a=indicateur de secteur de disque fixe incorrect
 BErr_0b=mauvais cylindre de disque fixe
 BErr_0c=piste non prise en charge
 BErr_0d=nombre de secteurs invalide sur le format de disque fixe
-BErr_0e=marque d'adresse de données contrôlée par disque fixe détectée
-BErr_0f=niveau d'arbitrage DMA de disque fixe hors plage
+BErr_0e="marque d'adresse de données contrôlée par disque fixe détectée"
+BErr_0f="niveau d'arbitrage DMA de disque fixe hors plage"
 BErr_10=erreur ECC/CRC pendant la lecture du disque
 BErr_11=erreur de données de disque fixe récupérable, données corrigées par ECC
 BErr_20=erreur de contrôleur
 BErr_40=échec de recherche
-BErr_80=le lecteur n'est pas prêt
-BErr_aa=le lecteur de disque fixe n'est pas prêt
+BErr_80="le lecteur n'est pas prêt"
+BErr_aa="le lecteur de disque fixe n'est pas prêt"
 BErr_bb=erreur non définie du disque fixe
-BErr_cc=erreur d'écriture de disque fixe sur le lecteur choisi
-BErr_e0=erreur d'état du disque fixe
-BErr_ff=échec de l'opération de détection
+BErr_cc="erreur d'écriture de disque fixe sur le lecteur choisi"
+BErr_e0="erreur d'état du disque fixe"
+BErr_ff="échec de l'opération de détection"
 
 DErr=%r "Code d'erreur DOS : 0x" %b %_ --> %_
 DErr_01=Numéro de fonction invalide
@@ -97,4 +97,4 @@ DErr_05=Accès refusé
 DErr_06=Handle invalide
 DErr_08=Mémoire insuffisante
 DErr_0f=Lecteur invalide spécifié
-DErr_15=Le lecteur n'est pas prêt
+DErr_15="Le lecteur n'est pas prêt"


### PR DESCRIPTION
In French, EDICT is currently (1.3-RC5) hanging when it is launched because a single quote wasn't quoted by a
different type of quote in the TITLE element. Hopefully this update will fix this issue, all other single quotes have been wrapped by double quotes as well.