### PR TITLE
Removed spaces that were not supposed be there

### DIFF
--- a/more/nls/more.no.UTF-8
+++ b/more/nls/more.no.UTF-8
@@ -4,7 +4,7 @@
 0.4:Tilgjengelig taster
 0.5:Nn
 0.6:Neste fil
-0.7:Qq
+0.7:Aa
 0.8:Avslutt program
 0.9:Mellomrom
 0.10:Neste side

--- a/xcopy/nls/xcopy.no
+++ b/xcopy/nls/xcopy.no
@@ -1,0 +1,81 @@
+# Norsk spr�kfil for (R)XCOPY 1.2
+
+Foresp�rsler og feilmeldinger
+1.1:Ugyldig antall parametere
+1.2:Ugyldig dato
+1.3:Ugyldig flagg
+1.4:Kildebanen er for lang
+1.5:Ugyldig spesifikasjon for kildedisk
+1.6:Kildebanen ble ikke funnet
+1.7:Kildebanen er for lang
+1.8:M�lbanen er for lang
+1.9:Ugyldig spesifikasjon for m�ldisk
+1.10:Er
+1.11:et filnavn
+1.12:eller et mappenavn for m�let
+1.13:Fil
+1.14:Mappe
+1.15:M�lbanen er for lang
+1.16:Kan ikke utf�re syklisk kopi
+1.17:Trykk p� returtasten for � fortsette
+1.18:Filen ble ikke funnet
+
+# Hjelpemeldinger
+2.1:Kopierer filer og filtre.
+2.2:XCOPY kilde [m�l] [/bryter] -- KOMME TILBAKE TIL DENNE
+2.3:  kilde        Angir mappenavnet og/eller navn p� fil(er) som skal kopieres.
+2.4:  m�l          Angir bane og/eller navnet til de(n) ny(e) filen(e).
+2.5:  /A           Kopierer bare filer hvor Arkiv-attributtet er satt,
+2.6:               uten at attributtet endres p� kildefilen(e).
+2.7:  /C           Fortsetter kopieringen selv om feil oppst�r.
+2.8:  /D[:M/D/Y]   Kopierer bare filer som har blitt endret p�
+2.9:               eller etter den angitte datoen. Hvis ingen dato angis
+2.10:              vil kun filer som er nyere enn m�lfilene bli kopiert.
+2.11:  /E          Kopierer undermapper, selv om de er tomme.
+2.12:  /F          Vis fullstendige kilde- og m�lnavn under kopieringen.
+2.13:  /H          Kopierer skjulte filer og systemfiler i tillegg til ubeskyttede filer.
+2.14:  /I          Hvis det ikke er oppgitt et m�l og det skal kopieres mer enn en fil,
+2.15:              blir mappen angitt som m�l.
+2.16:  /L          Vis filene uten � kopiere dem. (simulert kopiering)
+2.17:  /M          Kopierer kun filer hvor Arkiv-attributtet satt, og sl�r av attributtet p�
+2.18:              kildefilene etter kopieringen er ferdig.
+2.19:  /N          Skjuler foresp�rsel om overskriving av filer som allerede eksisterer,
+2.20:              og hopper i stedet over disse filene.
+2.21:  /P          Sp�r om bekreftelse f�r hver m�lfil opprettes.
+2.22:  /Q          Stille modus, viser ikke kopierte filnavn.
+2.23:  /R          Overskriv filer med skrivebeskyttelse i tillegg til filer uten skrivebeskyttelse.
+2.24:  /S          Kopierer mapper og undermapper, unntatt tomme.
+2.25:  /T          Oppretter mappestrukturen uten � kopiere over filene. Tomme
+2.26:              mapper vil ikke bli kopiert. For � kopiere tomme mapper, bruk bryteren /E.
+2.27:  /V          Verifiserer hver nye fil.
+2.28:  /W          Venter p� et tastetrykk f�r kopieringen starter.
+2.29:  /Y          Skjuler foresp�rsel om overskriving av filer som allerede eksisterer,
+2.30:              og overskriver disse filene.
+2.31:  /-Y         Sp�r om bekreftelse f�r eksisterende
+2.32:              m�lfiler overskrives.
+2.33:Bryteren /Y eller /N kan v�re stilt inn p� forh�nd i milj�variabelen COPYCMD.
+2.34:Dette kan overstyres med /-Y p� kommandolinjen.
+2.35:trykk returtasten for mer
+
+# Flere meldinger
+1.19:fil(er) kopiert
+1.20:Kan ikke opprette mappen
+1.21:Filen kan ikke kopieres til seg selv.
+1.22:Lesetilgang nektet
+1.23:Ikke nok tilgjengelig lagringsplass i m�lbanen
+1.24:Skrivetilgang nektet
+1.25:Ikke nok tilgjengelig lagringsplass i m�lbanen
+1.26:Kopierer
+
+# disse tre benyttes i shared.inc:
+25.0:Kan ikke �pne kildefil
+25.1:Kan ikke opprette m�let
+25.2:Skrivefeil p� m�ldisken
+
+# flere bekreftelsesmeldinger, m� starte med stor bokstav.
+# 3.2 til og med 3.5 m� starte forskjellig:
+3.1:Overskriv
+3.2:Ja
+3.3:Nei
+3.4:Overskriv alle
+3.5:Hopp over alle

--- a/xcopy/nls/xcopy.no.UTF-8
+++ b/xcopy/nls/xcopy.no.UTF-8
@@ -1,60 +1,60 @@
-# Norsk språkfil for (R)XCOPY 1.2
+# Norsk sprï¿½kfil for (R)XCOPY 1.2
 
-Forespørsler og feilmeldinger
-1.1: Ugyldig antall parametere
-1.2: Ugyldig dato
-1.3: Ugyldig flagg
-1.4: Kildebanen er for lang
-1.5: Ugyldig spesifikasjon for kildedisk
-1.6: Kildebanen ble ikke funnet
-1.7: Kildebanen er for lang
-1.8: Målbanen er for lang
-1.9: Ugyldig spesifikasjon for måldisk
-1.10: Er
-1.11: et filnavn
-1.12: eller et mappenavn for målet
-1.13: Fil
-1.14: Mappe
-1.15: Målbanen er for lang
-1.16: Kan ikke utføre syklisk kopi
-1.17: Trykk på returtasten for å fortsette
-1.18: Filen ble ikke funnet
+Forespï¿½rsler og feilmeldinger
+1.1:Ugyldig antall parametere
+1.2:Ugyldig dato
+1.3:Ugyldig flagg
+1.4:Kildebanen er for lang
+1.5:Ugyldig spesifikasjon for kildedisk
+1.6:Kildebanen ble ikke funnet
+1.7:Kildebanen er for lang
+1.8:Mï¿½lbanen er for lang
+1.9:Ugyldig spesifikasjon for mï¿½ldisk
+1.10:Er
+1.11:et filnavn
+1.12:eller et mappenavn for mï¿½let
+1.13:Fil
+1.14:Mappe
+1.15:Mï¿½lbanen er for lang
+1.16:Kan ikke utfï¿½re syklisk kopi
+1.17:Trykk pï¿½ returtasten for ï¿½ fortsette
+1.18:Filen ble ikke funnet
 
 # Hjelpemeldinger
-2.1: Kopierer filer og filtre.
-2.2:XCOPY kilde [mål] [/bryter] -- KOMME TILBAKE TIL DENNE
-2.3:  kilde        Angir mappenavnet og/eller navn på fil(er) som skal kopieres.
-2.4:  mål          Angir bane og/eller navnet til de(n) ny(e) filen(e).
+2.1:Kopierer filer og filtre.
+2.2:XCOPY kilde [mï¿½l] [/bryter] -- KOMME TILBAKE TIL DENNE
+2.3:  kilde        Angir mappenavnet og/eller navn pï¿½ fil(er) som skal kopieres.
+2.4:  mï¿½l          Angir bane og/eller navnet til de(n) ny(e) filen(e).
 2.5:  /A	   Kopierer bare filer hvor Arkiv-attributtet er satt,
-2.6: 		   uten at attributtet endres på kildefilen(e).
-2.7:  /C	   Fortsetter kopieringen selv om feil oppstår.
-2.8:  /D[:M/D/Y]   Kopierer bare filer som har blitt endret på
+2.6: 		   uten at attributtet endres pï¿½ kildefilen(e).
+2.7:  /C	   Fortsetter kopieringen selv om feil oppstï¿½r.
+2.8:  /D[:M/D/Y]   Kopierer bare filer som har blitt endret pï¿½
 2.9:               eller etter den angitte datoen. Hvis ingen dato angis
-2.10:		    vil kun filer som er nyere enn målfilene bli kopiert.
+2.10:		    vil kun filer som er nyere enn mï¿½lfilene bli kopiert.
 2.11:  /E	    Kopierer undermapper, selv om de er tomme.
-2.12:  /F	    Vis fullstendige kilde- og målnavn under kopieringen.
+2.12:  /F	    Vis fullstendige kilde- og mï¿½lnavn under kopieringen.
 2.13:  /H	    Kopierer skjulte filer og systemfiler i tillegg til ubeskyttede filer.
-2.14:  /I	    Hvis det ikke er oppgitt et mål og det skal kopieres mer enn en fil,
-2.15:  		    blir mappen angitt som mål.
-2.16:  /L	    Vis filene uten å kopiere dem. (simulert kopiering)
-2.17:  /M	    Kopierer kun filer hvor Arkiv-attributtet satt, og slår av attributtet på
+2.14:  /I	    Hvis det ikke er oppgitt et mï¿½l og det skal kopieres mer enn en fil,
+2.15:  		    blir mappen angitt som mï¿½l.
+2.16:  /L	    Vis filene uten ï¿½ kopiere dem. (simulert kopiering)
+2.17:  /M	    Kopierer kun filer hvor Arkiv-attributtet satt, og slï¿½r av attributtet pï¿½
 2.18:  		    kildefilene etter kopieringen er ferdig.
-2.19:  /N	    Skjuler forespørsel om overskriving av filer som allerede eksisterer,
+2.19:  /N	    Skjuler forespï¿½rsel om overskriving av filer som allerede eksisterer,
 2.20:  		    og hopper i stedet over disse filene.
-2.21:  /P	    Spør om bekreftelse før hver målfil opprettes.
+2.21:  /P	    Spï¿½r om bekreftelse fï¿½r hver mï¿½lfil opprettes.
 2.22:  /Q	    Stille modus, viser ikke kopierte filnavn.
 2.23:  /R	    Overskriv filer med skrivebeskyttelse i tillegg til filer uten skrivebeskyttelse.
 2.24:  /S	    Kopierer mapper og undermapper, unntatt tomme.
-2.25:  /T	    Oppretter mappestrukturen uten å kopiere over filene. Tomme
-2.26:               mapper vil ikke bli kopiert. For å kopiere tomme mapper, bruk bryteren /E.
+2.25:  /T	    Oppretter mappestrukturen uten ï¿½ kopiere over filene. Tomme
+2.26:               mapper vil ikke bli kopiert. For ï¿½ kopiere tomme mapper, bruk bryteren /E.
 2.27:  /V	    Verifiserer hver nye fil.
-2.28:  /W	    Venter på et tastetrykk før kopieringen starter.
-2.29:  /Y	    Skjuler forespørsel om overskriving av filer som allerede eksisterer,
+2.28:  /W	    Venter pï¿½ et tastetrykk fï¿½r kopieringen starter.
+2.29:  /Y	    Skjuler forespï¿½rsel om overskriving av filer som allerede eksisterer,
 2.30:  		    og overskriver disse filene.
-2.31:  /-Y	    Spør om bekreftelse før eksisterende
-2.32:               målfiler overskrives.
-2.33:Bryteren /Y eller /N kan være stilt inn på forhånd i miljøvariabelen COPYCMD.
-2.34:Dette kan overstyres med /-Y på kommandolinjen.
+2.31:  /-Y	    Spï¿½r om bekreftelse fï¿½r eksisterende
+2.32:               mï¿½lfiler overskrives.
+2.33:Bryteren /Y eller /N kan vï¿½re stilt inn pï¿½ forhï¿½nd i miljï¿½variabelen COPYCMD.
+2.34:Dette kan overstyres med /-Y pï¿½ kommandolinjen.
 2.35:trykk returtasten for mer
 
 # Flere meldinger
@@ -62,23 +62,23 @@ Forespørsler og feilmeldinger
 1.20:Kan ikke opprette mappen
 1.21:Filen kan ikke kopieres til seg selv.
 1.22:Lesetilgang nektet
-1.23:Ikke nok tilgjengelig lagringsplass i målbanen
+1.23:Ikke nok tilgjengelig lagringsplass i mï¿½lbanen
 1.24:Skrivetilgang nektet
-1.25:Ikke nok tilgjengelig lagringsplass i målbanen
+1.25:Ikke nok tilgjengelig lagringsplass i mï¿½lbanen
 1.26:Kopierer
 
 # disse tre benyttes i shared.inc:
-25.0:Kan ikke åpne kildefil
-25.1:Kan ikke opprette målet
-25.2:Skrivefeil på måldisken
+25.0:Kan ikke ï¿½pne kildefil
+25.1:Kan ikke opprette mï¿½let
+25.2:Skrivefeil pï¿½ mï¿½ldisken
 
-# flere bekreftelsesmeldinger, må starte med stor bokstav.
-# 3.2 til og med 3.5 må starte forskjellig:
-3.1: Overskriv
-3.2: Ja
-3.3: Nei
-3.4: Overskriv alle
-3.5: Hopp over alle
+# flere bekreftelsesmeldinger, mï¿½ starte med stor bokstav.
+# 3.2 til og med 3.5 mï¿½ starte forskjellig:
+3.1:Overskriv
+3.2:Ja
+3.3:Nei
+3.4:Overskriv alle
+3.5:Hopp over alle
 
 
 


### PR DESCRIPTION
Removed spaces that were not meant to be there. Somehow this affected the input from the user, e.g. the user could not press F to select File or O to select Overwrite, but had to put a space in front of F for it to be recognised properly