### PR TITLE
Add simplified Chinese (GB2312) support (experimental) for DOSSHELL

### DIFF
--- a/dosshell/nls/dosshell.zh
+++ b/dosshell/nls/dosshell.zh
@@ -1,0 +1,58 @@
+# Chinese strings written by Heavysnowjakarta
+# To print it correctly, you have to install Chinese charactor system preciously. So far FreeDOS can not deal with it alone.
+
+0.0: FDTUI 是 FreeDOS 的一种 TUI 图形程序。
+0.1: Copyright (C) 2017-2020 Ercan Ersoy
+0.2: FDTUI 以 GNU GPL version 2 和 GNU GPL version 3 协议发布。
+
+1.0:无法初始化子系统。
+1.1:\r\n按任意键返回 DOSSHELL。
+
+2.0:内置应用
+2.1:文件管理器
+2.2:运行
+
+3.0:退出
+3.1:退出
+
+4.0:文件管理器
+
+5.0:文件
+5.1:打开
+5.2:新建文件夹
+5.3:退出
+
+6.0:编辑
+6.1:剪切
+6.2:复制
+6.3:粘贴
+6.4:重命名
+6.5:属性
+6.6:存档
+6.7:隐藏
+6.8:只读
+6.9:系统
+6.10:删除
+
+7.0:查看
+7.1:刷新
+7.2:显示存档项目
+7.3:显示隐藏项目
+7.4:显示只读项目
+7.5:显示系统项目
+
+8.0:打开
+8.1:后退
+8.2:前进
+8.3:上一级
+
+9.0:新建文件夹
+9.1:文件夹名称：
+
+10.0:重命名
+10.1:新名称：
+
+11.0:文件属性：
+
+12.0:运行
+12.1:输入运行命令：


### PR DESCRIPTION
Now FreeDOS doesn’t support Chinese well. This pr is to test the possibility to let FreeDOS support Chinese. An i18n page is added to a program (dosshell) in GB2312 and it should works with Chinese systems.