### PR TITLE
Improve Turkish translations

### DIFF
--- a/fdi-x86/nls/SETUP.TR
+++ b/fdi-x86/nls/SETUP.TR
@@ -1,36 +1,36 @@
 # Welcome Message
-WELCOME_DEF=/fLightGreen %1 /fCyan %2 /fGray kurulum programna hoŸ geldiniz.
-WELCOME_ADV= /fLightGreen %1 /fCyan %2 /fGray /fLightRed geliŸmiŸ /fGray kurulum programna hoŸ geldiniz.
+WELCOME_DEF=/fLightGreen %1 /fCyan %2 /fGray "kurulum programna hoŸ geldiniz."
+WELCOME_ADV= /fLightGreen %1 /fCyan %2 /fGray /fLightRed geliŸmiŸ /fGray "kurulum programna hoŸ geldiniz."
 WELCOME_0=/p
-WELCOME_1=/fLightGreen "%1" /fGray tam bir iŸletim sistemidir. Kurulum iŸlemi, mevcut iŸletim /p /fLightRed /BlinkON "sisteminizin zerine yazp silinmesine neden olabilir." /BlinkOff /fGray /p
-WELCOME_2=/fGray /c32 E§er yapmak istedi§iniz /fLightRed "bu de§ilse kurulumu srdrmeyin." /fGray
+WELCOME_1=/fLightGreen "%1" /fGray "tam bir iŸletim sistemidir. Kurulum iŸlemi, mevcut iŸletim" /p /fLightRed /BlinkON "sisteminizin zerine yazp silinmesine neden olabilir." /BlinkOff /fGray /p
+WELCOME_2=/fGray /c32 "E§er yapmak istedi§iniz" /fLightRed "bu de§ilse kurulumu srdrmeyin." /fGray
 WELCOME_3=
 WELCOME_4=
 WELCOME_5=/p
 
 HRULE=/fDarkGray /x 0xC4 /fGray
 
-CONTINUE=/p Srdrmek istiyor musunuz? /c32
-REBOOT=/p imdi yeniden baŸlatmak istiyor musunuz? /c32
+CONTINUE=/p "Srdrmek istiyor musunuz?" /c32
+REBOOT=/p "imdi yeniden baŸlatmak istiyor musunuz?" /c32
 
-AUTO_YES=/s- [E,H]? /fWhite E /fGray
-AUTO_NO=/s- [E,H]? /fWhite H /fGray
+AUTO_YES=/s- "[E,H]?" /fWhite "E" /fGray
+AUTO_NO=/s- "[E,H]?" /fWhite "H" /fGray
 AUTO_FMT=/s- "[T,H,P]?" /fWhite "H" /fGray
 
 PROMPT_YESNO=/s EH
 PROMPT_FMT=/s THP
 
-ABORTED=/fLightRed %1 %2 kurulumu iptal edildi. /e /fGray /bBlack
+ABORTED=/fLightRed %1 %2 "kurulumu iptal edildi." /e /fGray /bBlack
 
-PARTITION_AUTO=/fWhite %1 /fGray srcsn kendili§inden b”lmlendir.
-PARTITION_WARN=/fYellow ˜KAZ: /fGray KERNL86 i‡in 2 GB de§erinden dŸk bir FAT16 b”lm gereklidir.
-PARTITION_MBR=/fWhite %1 /fGray srcs zerinde Ana ™nykleme Kaydn gncelle.
-PARTITION_ACTIVE=/fWhite %1 /fGray disk b”lmn etkin olarak ayarla.
-PARTITION_DONE=/p Yeni b”lmlendirme Ÿemasnn etkin olabilmesi i‡in bilgisayarnz yeniden baŸlatn.
+PARTITION_AUTO=/fWhite %1 /fGray "srcsn kendili§inden b”lntlendir".
+PARTITION_WARN=/fYellow "UYARI:" /fGray "KERNL86 i‡in 2 GB'den k‡k bir FAT16 b”lnts gerekiyor."
+PARTITION_MBR=/fWhite %1 /fGray "srcs zerinde Ana ™nykleme Kaydn gncelle."
+PARTITION_ACTIVE=/fWhite %1 /fGray "disk b”lntsn etkin olarak ayarla."
+PARTITION_DONE=/p "Yeni b”lntlendirme Ÿemasn etkinleŸtirmek i‡in bilgisayar yeniden baŸlatn."
 
-FORMAT=/fWhite %1 /fGray srcs bi‡imlendirilmiŸ g”zkmyor.
-FORMAT_DEF=Srcnz bi‡imlendirmek istiyor musunuz? /c32
-FORMAT_ADV=Srcnz nasl bi‡imlendirmek istersiniz? /s- /c32 ( /fWhite T /fGray am, /c32 /fWhite H /fGray zl, /c32 ˜ /fWhite p /fGray tal) /c32
+FORMAT=/fWhite %1 /fGray "srcs bi‡imlendirilmemiŸ g”rnyor."
+FORMAT_DEF="Srcnz bi‡imlendirmek istiyor musunuz?" /c32
+FORMAT_ADV="Srcnz nasl bi‡imlendirmek istiyorsunuz?" /s- /c32 "(" /fWhite "T" /fGray "am", /c32 /fWhite "H" /fGray "zl", /c32 "˜" /fWhite "p" /fGray "tal)" /c32
 
 FILESYSTEM_TEST=/fWhite %1 /fGray srcsndeki dosya sistemi snanyor.
 INSERT_DISKETTE=/fWhite #%1 /fGray (%2) numaral disketi /fWhite %3 /fGray srcsne yerleŸtirin.
@@ -56,7 +56,7 @@ CFG_FILES=/fWhite %1 /fGray srcsndeki sistem yaplandrma dosyalarn de§iŸt
 STATUS_MSG=Kurulum ayarlar: /p
 STATUS_CPU=/r4/c32 Platform (CPU) /fWhite %1 /fGray (%2)
 STATUS_FROM=/r4/c32 /fWhite %1 /fGray konumundan ykle
-STATUS_DRV=/r4/c32 Hedef src: /fWhite %1 /fGray (disk %2, b”lm %3)
+STATUS_DRV=/r4/c32 Hedef src: /fWhite %1 /fGray (disk %2, b”lnt %3)
 STATUS_DOS=/r4/c32 DOS yolu ykle: /fWhite %1 /fGray
 STATUS_BAK=/r4/c32 Eski iŸletim sistemi yedekle: /fWhite %1 /fGray
 STATUS_POS=/r4/c32 Eski iŸletim sistemi dizini: /fWhite %1 /fGray
@@ -72,7 +72,7 @@ DO_BACKUP=Bir ”nceki iŸletim sistemi dosyalarnn yede§i /fWhite %1 /fGray konum
 DO_ERASE=Eski /fWhite %1 /fGray dizini ve dosyalar siliniyor.
 DO_SYSFILES=Yeni sistem dosyalar /fWhite %1 /fGray srcsne aktarlyor.
 DO_FORCEMBR=/fWhite %1 /fGray srcsndeki A™K zorla gncelleniyor.
-DO_ACTIVATE=Etkin ”nykleme b”lm /fWhite %1 /fGray diski ve /fWhite %2 /fGray b”lm olarak ayarlanyor.
+DO_ACTIVATE=Etkin ”nykleme b”lnts /fWhite %1 /fGray diski ve /fWhite %2 /fGray b”lnts olarak ayarlanyor.
 DO_CFGFILES=Yeni yaplandrma dosyalar /fWhite %1 /fGray srcsne aktarlyor.
 DO_PREPARE=€alŸtrlabilir dosyalarn ve izlencelerin kurulumuna hazrlanlyor.
 DO_INSTALL=/fWhite %2 /fGray i‡in /fLightGreen %1 /fGray dosyalar ykleniyor.
@@ -110,7 +110,7 @@ HELP_15=/n
 
 # Error Messages
 ERROR_CRITICAL=/fLightRed KR˜T˜K hata: /fGray /c32
-ERROR_NoHDD=B”lmlendirilmiŸ ve bi‡imlendirilmiŸ bir sabit disk bulunamad.
+ERROR_NoHDD=B”lntlendirilmiŸ ve bi‡imlendirilmiŸ bir sabit disk bulunamad.
 ERROR_MINOR=/fLightRed hata: /fGray /c32
 ERROR_Option=Bilinmeyen veya ge‡ersiz komut satr se‡ene§i /s- "`" /fWhite %1 /fGray "'."
 ERROR_NoCfgEnv=Temel sistem yaplandrmas ve yol ayarlar belirlenemiyor.

--- a/fdi-x86/nls/SETUP.TR.UTF-8
+++ b/fdi-x86/nls/SETUP.TR.UTF-8
@@ -1,36 +1,36 @@
 # Welcome Message
-WELCOME_DEF=/fLightGreen %1 /fCyan %2 /fGray kurulum programına hoş geldiniz.
-WELCOME_ADV= /fLightGreen %1 /fCyan %2 /fGray /fLightRed gelişmiş /fGray kurulum programına hoş geldiniz.
+WELCOME_DEF=/fLightGreen %1 /fCyan %2 /fGray "kurulum programına hoş geldiniz."
+WELCOME_ADV= /fLightGreen %1 /fCyan %2 /fGray /fLightRed gelişmiş /fGray "kurulum programına hoş geldiniz."
 WELCOME_0=/p
-WELCOME_1=/fLightGreen "%1" /fGray tam bir işletim sistemidir. Kurulum işlemi, mevcut işletim /p /fLightRed /BlinkON "sisteminizin üzerine yazıp silinmesine neden olabilir." /BlinkOff /fGray /p
-WELCOME_2=/fGray /c32 Eğer yapmak istediğiniz /fLightRed "bu değilse kurulumu sürdürmeyin." /fGray
+WELCOME_1=/fLightGreen "%1" /fGray "tam bir işletim sistemidir. Kurulum işlemi, mevcut işletim" /p /fLightRed /BlinkON "sisteminizin üzerine yazıp silinmesine neden olabilir." /BlinkOff /fGray /p
+WELCOME_2=/fGray /c32 "Eğer yapmak istediğiniz" /fLightRed "bu değilse kurulumu sürdürmeyin." /fGray
 WELCOME_3=
 WELCOME_4=
 WELCOME_5=/p
 
 HRULE=/fDarkGray /x 0xC4 /fGray
 
-CONTINUE=/p Sürdürmek istiyor musunuz? /c32
-REBOOT=/p Şimdi yeniden başlatmak istiyor musunuz? /c32
+CONTINUE=/p "Sürdürmek istiyor musunuz?" /c32
+REBOOT=/p "Şimdi yeniden başlatmak istiyor musunuz?" /c32
 
-AUTO_YES=/s- [E,H]? /fWhite E /fGray
-AUTO_NO=/s- [E,H]? /fWhite H /fGray
+AUTO_YES=/s- "[E,H]?" /fWhite "E" /fGray
+AUTO_NO=/s- "[E,H]?" /fWhite "H" /fGray
 AUTO_FMT=/s- "[T,H,P]?" /fWhite "H" /fGray
 
 PROMPT_YESNO=/s EH
 PROMPT_FMT=/s THP
 
-ABORTED=/fLightRed %1 %2 kurulumu iptal edildi. /e /fGray /bBlack
+ABORTED=/fLightRed %1 %2 "kurulumu iptal edildi." /e /fGray /bBlack
 
-PARTITION_AUTO=/fWhite %1 /fGray sürücüsünü kendiliğinden bölümlendir.
-PARTITION_WARN=/fYellow İKAZ: /fGray KERNL86 için 2 GB değerinden düşük bir FAT16 bölümü gereklidir.
-PARTITION_MBR=/fWhite %1 /fGray sürücüsü üzerinde Ana Önyükleme Kaydını güncelle.
-PARTITION_ACTIVE=/fWhite %1 /fGray disk bölümünü etkin olarak ayarla.
-PARTITION_DONE=/p Yeni bölümlendirme şemasının etkin olabilmesi için bilgisayarınızı yeniden başlatın.
+PARTITION_AUTO=/fWhite %1 /fGray "sürücüsünü kendiliğinden bölüntülendir".
+PARTITION_WARN=/fYellow "UYARI:" /fGray "KERNL86 için 2 GB'den küçük bir FAT16 bölüntüsü gerekiyor."
+PARTITION_MBR=/fWhite %1 /fGray "sürücüsü üzerinde Ana Önyükleme Kaydını güncelle."
+PARTITION_ACTIVE=/fWhite %1 /fGray "disk bölüntüsünü etkin olarak ayarla."
+PARTITION_DONE=/p "Yeni bölüntülendirme şemasını etkinleştirmek için bilgisayarı yeniden başlatın."
 
-FORMAT=/fWhite %1 /fGray sürücüsü biçimlendirilmiş gözükmüyor.
-FORMAT_DEF=Sürücünüzü biçimlendirmek istiyor musunuz? /c32
-FORMAT_ADV=Sürücünüzü nasıl biçimlendirmek istersiniz? /s- /c32 ( /fWhite T /fGray am, /c32 /fWhite H /fGray ızlı, /c32 İ /fWhite p /fGray tal) /c32
+FORMAT=/fWhite %1 /fGray "sürücüsü biçimlendirilmemiş görünüyor."
+FORMAT_DEF="Sürücünüzü biçimlendirmek istiyor musunuz?" /c32
+FORMAT_ADV="Sürücünüzü nasıl biçimlendirmek istiyorsunuz?" /s- /c32 "(" /fWhite "T" /fGray "am", /c32 /fWhite "H" /fGray "ızlı", /c32 "İ" /fWhite "p" /fGray "tal)" /c32
 
 FILESYSTEM_TEST=/fWhite %1 /fGray sürücüsündeki dosya sistemi sınanıyor.
 INSERT_DISKETTE=/fWhite #%1 /fGray (%2) numaralı disketi /fWhite %3 /fGray sürücüsüne yerleştirin.
@@ -56,7 +56,7 @@ CFG_FILES=/fWhite %1 /fGray sürücüsündeki sistem yapılandırma dosyaların�
 STATUS_MSG=Kurulum ayarları: /p
 STATUS_CPU=/r4/c32 Platform (CPU) /fWhite %1 /fGray (%2)
 STATUS_FROM=/r4/c32 /fWhite %1 /fGray konumundan yükle
-STATUS_DRV=/r4/c32 Hedef sürücü: /fWhite %1 /fGray (disk %2, bölüm %3)
+STATUS_DRV=/r4/c32 Hedef sürücü: /fWhite %1 /fGray (disk %2, bölüntü %3)
 STATUS_DOS=/r4/c32 DOS yolu yükle: /fWhite %1 /fGray
 STATUS_BAK=/r4/c32 Eski işletim sistemi yedekle: /fWhite %1 /fGray
 STATUS_POS=/r4/c32 Eski işletim sistemi dizini: /fWhite %1 /fGray
@@ -72,7 +72,7 @@ DO_BACKUP=Bir önceki işletim sistemi dosyalarının yedeği /fWhite %1 /fGray 
 DO_ERASE=Eski /fWhite %1 /fGray dizini ve dosyaları siliniyor.
 DO_SYSFILES=Yeni sistem dosyaları /fWhite %1 /fGray sürücüsüne aktarılıyor.
 DO_FORCEMBR=/fWhite %1 /fGray sürücüsündeki AÖK zorla güncelleniyor.
-DO_ACTIVATE=Etkin önyükleme bölümü /fWhite %1 /fGray diski ve /fWhite %2 /fGray bölümü olarak ayarlanıyor.
+DO_ACTIVATE=Etkin önyükleme bölüntüsü /fWhite %1 /fGray diski ve /fWhite %2 /fGray bölüntüsü olarak ayarlanıyor.
 DO_CFGFILES=Yeni yapılandırma dosyaları /fWhite %1 /fGray sürücüsüne aktarılıyor.
 DO_PREPARE=Çalıştırılabilir dosyaların ve izlencelerin kurulumuna hazırlanılıyor.
 DO_INSTALL=/fWhite %2 /fGray için /fLightGreen %1 /fGray dosyaları yükleniyor.
@@ -110,7 +110,7 @@ HELP_15=/n
 
 # Error Messages
 ERROR_CRITICAL=/fLightRed KRİTİK hata: /fGray /c32
-ERROR_NoHDD=Bölümlendirilmiş ve biçimlendirilmiş bir sabit disk bulunamadı.
+ERROR_NoHDD=Bölüntülendirilmiş ve biçimlendirilmiş bir sabit disk bulunamadı.
 ERROR_MINOR=/fLightRed hata: /fGray /c32
 ERROR_Option=Bilinmeyen veya geçersiz komut satırı seçeneği /s- "`" /fWhite %1 /fGray "'."
 ERROR_NoCfgEnv=Temel sistem yapılandırması ve yol ayarları belirlenemiyor.

--- a/fdi/language/tr/FDSETUP.DEF
+++ b/fdi/language/tr/FDSETUP.DEF
@@ -24,7 +24,6 @@ LANG_EO=Esperanto
 LANG_NL=Hollandaca
 LANG_TR=TÅrkáe
 LANG_RU=Rusáa
-LANG_SV=òsveááe
 
 HELLO_FRAME=/w70 /h15 /c
 HELLO_OPTS=/w40 /h5 /c
@@ -44,22 +43,22 @@ EXIT="  Hayçr, DOS'a dîn"
 
 # STAGE400 - Partition screen specific
 NOPART_FRAME=/w60 /h10 /c
-NOPART_OPTS=/w44 /h5 /c
-NOPART=/s- /f  %1 %2 /f %3 " sÅrÅcÅsÅ bîlÅmlenmemiü gibi gîrÅnÅyor."
-PART?="SÅrÅcÅnÅzde bir bîlÅm oluüturmak ister misiniz?"
-PART_YES="  Evet, %1 sÅrÅcÅsÅnde bir bîlÅm oluütur"
+NOPART_OPTS=/w40 /h5 /c
+NOPART=/s- /f  %1 %2 /f %3 " sÅrÅcÅsÅ bîlÅntÅlenmemiü gibi gîrÅnÅyor."
+PART?="SÅrÅcÅnÅzde bir bîlÅntÅ oluüturmak ister misiniz?"
+PART_YES="  Evet, %1 sÅrÅcÅsÅnde bir bîlÅntÅ oluütur"
 # EXIT
 
 # STAGE400 - After partitioned specific
 PARTED_FRAME=/w60 /h11 /c
 PARTED_OPTS=/w40 /h5 /c
-PARTED=/s- "Yeni bîlÅm üemasçnçn etkinleütirilebilmesi iáin" /p "bilgisayarçnçzç yeniden baülatmançz gerekmektedir."
+PARTED=/s- "Yeni bîlÅntÅ üemasçnçn etkinleütirilebilmesi iáin" /p "bilgisayarçnçzç yeniden baülatmançz gerekiyor."
 REBOOT?="ûimdi yeniden baülatmak istiyor musunuz?"
 REBOOT_YES="  Evet, üimdi yeniden baülat"
 # EXIT
 REBOOT="Bilgisayarçnçz üimdi yeniden baülatçlacaktçr"
-PARTING_FRAME=/w40 /h5 /c
-PARTING="Sabit disk bîlÅmlendiriliyor..."
+PARTING_FRAME=/w34 /h5 /c
+PARTING="Sabit disk bîlÅntÅlendiriliyor..."
 
 # STAGE500 - Formating specific
 NOFORMAT_FRAME=/w55 /h10 /c
@@ -82,7 +81,7 @@ GATHERING="Kurulum hazçrlçßç iáin bazç bilgiler toplançyor..."
 # STAGE800 - Installing
 INSTALL_FRAME=/w62 /h10 /c
 INSTALL_OPTS=/w48 /h5 /c
-INSTALL=/s- /f %1 "%2" /f %3 " artçk kurulabilir."
+INSTALL=/s- /f %1 "%2" /f %3 " artçk kurulabilir.
 INSTALL?="Kurulumu sÅrdÅrmek istiyor musunuz?"
 INSTALL_YES="  Evet, %1 kurulsun"
 # EXIT
@@ -141,7 +140,7 @@ ERROR_XSYS="Sistem dosyalarçnçn %1 konumuna aktarçlmasç sçrasçnda hata."
 ERROR_CONFIG="Yeni yapçlandçrma dosyalarç kopyalançrken bir sorun áçktç."
 
 REBOOT_PAUSE=/f%1/c32 kurulum ortamçnç áçkarçp sistemi yeniden baülatmak iáin /p/e/c3 herhangi bir dÅßmeye veya áçkmak iáin /f%2 CTRL+C /f%1 dÅßmelerine basçn...
-REBOOT_FRAME=/w70 /h12 /c
+REBOOT_FRAME=/w70 /h8 /c
 REBOOT_WARN.1=MBR înyÅkleme kaydçnçn gÅncellemesini zorlamadçßçnçzç not /p etmenizi rica ederiz. Eßer
 REBOOT_WARN.2=/c32 sisteminiz înyÅklemeyi baüaramçyorsa /s- /c32 /f%1 "%2" /f%3 , /s+ lÅtfen kurulum ortamçnç/p
 REBOOT_WARN.3=kullanarak onu tekrar baülatçn ve üu komutu áalçütçrçn: "'" /s- /f%1 MBRZAP.BAT /f%3 "'" /s+. Bu,
@@ -166,12 +165,12 @@ KBL=" Daha az klavye seáeneßi..."
 KBA_FRAME=/w58 /h13 /c
 
 # FDASK200 - Backup old OS
-BACKUP_FRAME=/w70 /h16 /c
-BACKUP_OPTS=/w45 /h5 /c
-BACKUPADV_FRAME=/w64 /h11 /c
+BACKUP_FRAME=/w70 /h10 /c
+BACKUP_OPTS=/w45/h5 /c
+BACKUPADV_FRAME=/w70 /h11 /c
 BACKUPADV_OPTS=/w45 /h5 /c
-BACKUP=/f %1 %2 /f %3 " sÅrÅcÅsÅnde kurulu bir iületim sistemi bulundu."
-BACKUP?="Kurulumdan înce mevcut dosyalarç yedeklemek ister misiniz?"
+BACKUP=/f %1 %2 /f %3 /s- sÅrÅcÅsÅnde kurulu bir iületim sistemi bulundu.
+BACKUP?=Kurulumdan înce mevcut dosyalarç yedeklemek ister misiniz?
 BACKUPY="  Evet, mevcut dosyalarç yedekle"
 BACKUPZ="  Evet, mevcut dosyalarç ZIP olarak yedekle"
 BACKUPN="  Hayçr, yedekleme yapma"
@@ -182,23 +181,23 @@ TARGET?=Kurulum hedef dizini deßiütirilsin mi?
 TARGET_ASK=/f %1 /b %2 /d %3 %4
 
 # FDASK300 - Advanced mode Replace system files
-REPLACE_FRAME=/w62 /h8 /c
+REPLACE_FRAME=/w55 /h8 /c
 REPLACE_OPTS=/w40 /h5 /c
-REPLACE?="Sistem yapçlandçrma dosyalarçnçn yerine yenileri konulsun mu?"
+REPLACE?=Sistem yapçlandçrma dosyalarçnçn yerine yenileri konulsun mu?
 REPLACEY="  Evet, yenileriyle deßiütir "
 REPLACEN="  Hayçr, eski dosyalarç sakla"
 
 # FDASK400 - Advanced mode delete old OS files
-DELETE_FRAME=/w62 /h8 /c
+DELETE_FRAME=/w55 /h8 /c
 DELETE_OPTS=/w42 /h5 /c
-DELETE?=/f %1 %2 /f %3 "sÅrÅcÅsÅndeki tÅm eski dosyalar kaldçrçlsçn mç?"
+DELETE?=/f %1 %2 /f %3 /s- sÅrÅcÅsÅndeki tÅm eski dosyalar kaldçrçlsçn mç?
 DELETEY="  Evet, her üeyi kaldçr"
 DELETEN="  Hayçr, îylece bçrak"
 
 # FDASK500 - Advanced mode transfer system files
 XFER_FRAME=/w60 /h8 /c
 XFER_OPTS=/w45 /h5 /c
-XFER?=Yeni sistem dosyalarç /f %1 %2 /f %3 " sÅrÅcÅsÅne aktarçlsçn mç?"
+XFER?=Yeni sistem dosyalarç /f %1 %2 /f %3 /s- sÅrÅcÅsÅne aktarçlsçn mç?
 XFERY="  Evet, sistem dosyalarçnç aktar"
 XFERN="  Hayçr, sistem dosyalarçnç aktarma"
 

--- a/fdi/language/tr/utf-8/FDSETUP.DEF
+++ b/fdi/language/tr/utf-8/FDSETUP.DEF
@@ -44,21 +44,21 @@ EXIT="  Hayır, DOS'a dön"
 # STAGE400 - Partition screen specific
 NOPART_FRAME=/w60 /h10 /c
 NOPART_OPTS=/w40 /h5 /c
-NOPART=/s- /f  %1 %2 /f %3 " sürücüsü bölümlenmemiş gibi görünüyor."
-PART?="Sürücünüzde bir bölüm oluşturmak ister misiniz?"
-PART_YES="  Evet, %1 sürücüsünde bir bölüm oluştur"
+NOPART=/s- /f  %1 %2 /f %3 " sürücüsü bölüntülenmemiş gibi görünüyor."
+PART?="Sürücünüzde bir bölüntü oluşturmak ister misiniz?"
+PART_YES="  Evet, %1 sürücüsünde bir bölüntü oluştur"
 # EXIT
 
 # STAGE400 - After partitioned specific
 PARTED_FRAME=/w60 /h11 /c
 PARTED_OPTS=/w40 /h5 /c
-PARTED=/s- "Yeni bölüm şemasının etkinleştirilebilmesi için" /p "bilgisayarınızı yeniden başlatmanız gerekmektedir."
+PARTED=/s- "Yeni bölüntü şemasının etkinleştirilebilmesi için" /p "bilgisayarınızı yeniden başlatmanız gerekiyor."
 REBOOT?="Şimdi yeniden başlatmak istiyor musunuz?"
 REBOOT_YES="  Evet, şimdi yeniden başlat"
 # EXIT
 REBOOT="Bilgisayarınız şimdi yeniden başlatılacaktır"
 PARTING_FRAME=/w34 /h5 /c
-PARTING="Sabit disk bölümlendiriliyor..."
+PARTING="Sabit disk bölüntülendiriliyor..."
 
 # STAGE500 - Formating specific
 NOFORMAT_FRAME=/w55 /h10 /c

--- a/fdisk/help/fdisk.tr
+++ b/fdisk/help/fdisk.tr
@@ -1,3 +1,3 @@
 FDISK
 
-FDISK, sabit disklerde b”lm oluŸturmak ve kaldrmak i‡in kullanlan bir ara‡tr.
+FDISK, sabit disklerde b”lnt oluŸturmak ve kaldrmak i‡in kullanlan bir ara‡tr.

--- a/fdisk/help/fdisk.tr.UTF-8
+++ b/fdisk/help/fdisk.tr.UTF-8
@@ -1,3 +1,3 @@
 FDISK
 
-FDISK, sabit disklerde bölüm oluşturmak ve kaldırmak için kullanılan bir araçtır.
+FDISK, sabit disklerde bölüntü oluşturmak ve kaldırmak için kullanılan bir araçtır.

--- a/mirror/help/mirror.tr
+++ b/mirror/help/mirror.tr
@@ -10,8 +10,8 @@ S”zdizim:
 MIRROR [src:]
 MIRROR [/PARTN]
 
-  /PARTN    B”lm tablolarnn bir yede§ini A: srcsndeki diskete
-              PARTNSAV.FIL olarak kaydeder. B”lm tablolar UNFORMAT
+  /PARTN    B”lnt tablolarnn bir yede§ini A: srcsndeki diskete
+              PARTNSAV.FIL olarak kaydeder. B”lnt tablolar UNFORMAT
               srm 0.8 ile kurtarlabilir.
 
 

--- a/mirror/help/mirror.tr.UTF-8
+++ b/mirror/help/mirror.tr.UTF-8
@@ -10,8 +10,8 @@ Sözdizim:
 MIRROR [sürücü:]
 MIRROR [/PARTN]
 
-  /PARTN    Bölüm tablolarının bir yedeğini A: sürücüsündeki diskete
-              PARTNSAV.FIL olarak kaydeder. Bölüm tabloları UNFORMAT
+  /PARTN    Bölüntü tablolarının bir yedeğini A: sürücüsündeki diskete
+              PARTNSAV.FIL olarak kaydeder. Bölüntü tabloları UNFORMAT
               sürüm 0.8 ile kurtarılabilir.
 
 

--- a/v8power/help/tr/vinfo.tr
+++ b/v8power/help/tr/vinfo.tr
@@ -33,8 +33,8 @@ Genel sistem bilgisi izlencesi.
     /E n        Fiziki sabit disk #n (1, 2, vs.)'yi MBR (Ana ônyÅkleme Kaydç)
                 durumu iáin incele
                     0  - MBR tamamen boü
-                    5  - MBR sadece bîlÅm verileri iáeriyor
-                    10 - MBR în baülatma kodu iáeriyor
+                    5  - MBR yalnçzca bîlÅntÅ verisi iáeriyor
+                    10 - MBR înyÅkleme kodu iáeriyor
                     101 - Hata meydana geldi
 
 Bilhassa programcçlar ve Ar-Ge iáin faydalç olan daha fazla seáenekleri aüaßçda

--- a/v8power/help/tr/vinfo.tr.UTF-8
+++ b/v8power/help/tr/vinfo.tr.UTF-8
@@ -33,8 +33,8 @@ Genel sistem bilgisi izlencesi.
     /E n        Fiziki sabit disk #n (1, 2, vs.)'yi MBR (Ana Önyükleme Kaydı)
                 durumu için incele
                     0  - MBR tamamen boş
-                    5  - MBR sadece bölüm verileri içeriyor
-                    10 - MBR ön başlatma kodu içeriyor
+                    5  - MBR yalnızca bölüntü verisi içeriyor
+                    10 - MBR önyükleme kodu içeriyor
                     101 - Hata meydana geldi
 
 Bilhassa programcılar ve Ar-Ge için faydalı olan daha fazla seçenekleri aşağıda


### PR DESCRIPTION
@shidel, I'm not sure if it's a recent addition or not, but the strings in `fdi-x86` has quotes around strings, but rather strangely. They do not seem to include the space preceding and trailing the variable placeholder. Could you please have a look at my example couple of strings, and tell if I'm doing it alright?